### PR TITLE
remove: mandatory 'number' field from templates

### DIFF
--- a/src/mcnt/__init__.py
+++ b/src/mcnt/__init__.py
@@ -30,7 +30,6 @@ def create_note_type(col: Collection) -> dict[str, Any]:
     model["sortf"] = 0
 
     # Add Fields
-    col.models.add_field(model, col.models.new_field("number"))
     col.models.add_field(model, col.models.new_field("question"))
     col.models.add_field(model, col.models.new_field("a"))
     col.models.add_field(model, col.models.new_field("b"))

--- a/src/mcnt/card-templates/back_template.html
+++ b/src/mcnt/card-templates/back_template.html
@@ -3,12 +3,10 @@
 	if(void 0===window.Persistence){var e="github.com/SimonLammer/anki-persistence/",t="_default";if(window.Persistence_sessionStorage=function(){var i=!1;try{"object"==typeof window.sessionStorage&&(i=!0,this.clear=function(){for(var t=0;t<sessionStorage.length;t++){var i=sessionStorage.key(t);0==i.indexOf(e)&&(sessionStorage.removeItem(i),t--)}},this.setItem=function(i,n){void 0==n&&(n=i,i=t),sessionStorage.setItem(e+i,JSON.stringify(n))},this.getItem=function(i){return void 0==i&&(i=t),JSON.parse(sessionStorage.getItem(e+i))},this.removeItem=function(i){void 0==i&&(i=t),sessionStorage.removeItem(e+i)},this.getAllKeys=function(){for(var t=[],i=Object.keys(sessionStorage),n=0;n<i.length;n++){var s=i[n];0==s.indexOf(e)&&t.push(s.substring(e.length,s.length))}return t.sort()})}catch(n){}this.isAvailable=function(){return i}},window.Persistence_windowKey=function(i){var n=window[i],s=!1;"object"==typeof n&&(s=!0,this.clear=function(){n[e]={}},this.setItem=function(i,s){void 0==s&&(s=i,i=t),n[e][i]=s},this.getItem=function(i){return void 0==i&&(i=t),void 0==n[e][i]?null:n[e][i]},this.removeItem=function(i){void 0==i&&(i=t),delete n[e][i]},this.getAllKeys=function(){return Object.keys(n[e])},void 0==n[e]&&this.clear()),this.isAvailable=function(){return s}},window.Persistence=new Persistence_sessionStorage,Persistence.isAvailable()||(window.Persistence=new Persistence_windowKey("py")),!Persistence.isAvailable()){var i=window.location.toString().indexOf("title"),n=window.location.toString().indexOf("main",i);i>0&&n>0&&n-i<10&&(window.Persistence=new Persistence_windowKey("qt"))}}
 </script>
 
-{{#number}}<h3>Question #{{number}}</h3>{{/number}}
-{{#question}}<p>{{question}}</p>{{/question}}
+<div>{{question}}</div>
+<br/>
+<div id="answer-div"></div>
 
-<div id="answer-div">
-
-</div>
 <br/>
 <hr>
 

--- a/src/mcnt/card-templates/front_template.html
+++ b/src/mcnt/card-templates/front_template.html
@@ -3,13 +3,7 @@
 	if(void 0===window.Persistence){var e="github.com/SimonLammer/anki-persistence/",t="_default";if(window.Persistence_sessionStorage=function(){var i=!1;try{"object"==typeof window.sessionStorage&&(i=!0,this.clear=function(){for(var t=0;t<sessionStorage.length;t++){var i=sessionStorage.key(t);0==i.indexOf(e)&&(sessionStorage.removeItem(i),t--)}},this.setItem=function(i,n){void 0==n&&(n=i,i=t),sessionStorage.setItem(e+i,JSON.stringify(n))},this.getItem=function(i){return void 0==i&&(i=t),JSON.parse(sessionStorage.getItem(e+i))},this.removeItem=function(i){void 0==i&&(i=t),sessionStorage.removeItem(e+i)},this.getAllKeys=function(){for(var t=[],i=Object.keys(sessionStorage),n=0;n<i.length;n++){var s=i[n];0==s.indexOf(e)&&t.push(s.substring(e.length,s.length))}return t.sort()})}catch(n){}this.isAvailable=function(){return i}},window.Persistence_windowKey=function(i){var n=window[i],s=!1;"object"==typeof n&&(s=!0,this.clear=function(){n[e]={}},this.setItem=function(i,s){void 0==s&&(s=i,i=t),n[e][i]=s},this.getItem=function(i){return void 0==i&&(i=t),void 0==n[e][i]?null:n[e][i]},this.removeItem=function(i){void 0==i&&(i=t),delete n[e][i]},this.getAllKeys=function(){return Object.keys(n[e])},void 0==n[e]&&this.clear()),this.isAvailable=function(){return s}},window.Persistence=new Persistence_sessionStorage,Persistence.isAvailable()||(window.Persistence=new Persistence_windowKey("py")),!Persistence.isAvailable()){var i=window.location.toString().indexOf("title"),n=window.location.toString().indexOf("main",i);i>0&&n>0&&n-i<10&&(window.Persistence=new Persistence_windowKey("qt"))}}
 </script>
 
-{{#number}}<h3>Question #{{number}}</h3>{{/number}}
-{{#question}}
-<div class="question-div">
-	<div id="tts">{{tts TTSLang speed=0.8 voices=Apple_Samantha,Microsoft_Haruka:question}}</div>
-	<div>{{question}}</div>
-</div>
-{{/question}}
+<div>{{question}}</div>
 <br/>
 <div id="answer-div"></div>
 


### PR DESCRIPTION
Mandating the use of 'number' adds an unnecessary burden. Since this needs to be globally unique it will conflict with not just any other exam added that uses this plugin but *any* card that has a field named accordingly. Sorting by question is consistent with default behaviour. I also removed the TTS from this small section as it didn't appear to be respecting the "false" setting.